### PR TITLE
fix:header information setting error

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -285,13 +285,13 @@ func (c *ResponseCache) fillWithCacheWriter(cacheWriter *responseCacheWriter, wi
 	c.Data = buf
 	if !withoutHeader {
 		c.Header = make(map[string][]string)
-		for _, val := range cacheWriter.Header.GetHeaders() {
-			if c.Header.Values(b2s(val.GetKey())) != nil {
-				c.Header.Add(b2s(val.GetKey()), b2s(val.GetValue()))
+		cacheWriter.Header.VisitAll(func(key, value []byte) {
+			if c.Header.Get(b2s(key)) != "" {
+				c.Header.Add(b2s(key), b2s(value))
 			} else {
-				c.Header.Set(b2s(val.GetKey()), b2s(val.GetValue()))
+				c.Header.Set(b2s(key), b2s(value))
 			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
fix
#### What this PR does / why we need it (en: English/zh: Chinese):

en: When using cache middleware, when cache hit, the response content type is incorrect. we should use visitall to traverse
zh:在使用cache中间件的时候，当cache hit的时候，响应content type不正确。应该使用visitall来遍历

#### Which issue(s) this PR fixes:

