### PR TITLE
feat: add freecache middleware

### DIFF
--- a/example/freecache/freecache_example.go
+++ b/example/freecache/freecache_example.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 cyhone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+* This file may have been modified by CloudWeGo authors. All CloudWeGo
+* Modifications are Copyright 2022 CloudWeGo Authors.
+*/
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/hertz-contrib/cache"
+	"github.com/hertz-contrib/cache/persist"
+)
+
+func main() {
+	h := server.New()
+
+	memoryStore := persist.NewFreeCacheStore(10 * 1024 * 1024)
+
+	h.Use(cache.NewCacheByRequestURI(memoryStore, 2*time.Second))
+	h.GET("/hello", func(ctx context.Context, c *app.RequestContext) {
+		c.String(http.StatusOK, "hello world")
+	})
+	h.Spin()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/cloudwego/hertz v0.4.2
+	github.com/coocood/freecache v1.2.4
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cloudwego/hertz v0.4.2 h1:Ntfs5MdPoKeFSbyStU2drM4CizOkEfYWsB9s1Q3taPY
 github.com/cloudwego/hertz v0.4.2/go.mod h1:K1U0RlU07CDeBINfHNbafH/3j9uSgIW8otbjUys3OPY=
 github.com/cloudwego/netpoll v0.3.1 h1:xByoORmCLIyKZ8gS+da06WDo3j+jvmhaqS2KeKejtBk=
 github.com/cloudwego/netpoll v0.3.1/go.mod h1:1T2WVuQ+MQw6h6DpE45MohSvDTKdy2DlzCx2KsnPI4E=
+github.com/coocood/freecache v1.2.4 h1:UdR6Yz/X1HW4fZOuH0Z94KwG851GWOSknua5VUbb/5M=
+github.com/coocood/freecache v1.2.4/go.mod h1:RBUWa/Cy+OHdfTGFEhEuE1pMCMX51Ncizj7rthiQ3vk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/persist/freecache.go
+++ b/persist/freecache.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 cyhone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+* This file may have been modified by CloudWeGo authors. All CloudWeGo
+* Modifications are Copyright 2022 CloudWeGo Authors.
+*/
+package persist
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/coocood/freecache"
+)
+
+type FreeCacheStore struct {
+	cache *freecache.Cache
+}
+
+func NewFreeCacheStore(size int) *FreeCacheStore {
+	return &FreeCacheStore{
+		cache: freecache.NewCache(size),
+	}
+}
+
+func (store *FreeCacheStore) Set(ctx context.Context, key string, value interface{}, expire time.Duration) error {
+	payload, err := Serialize(value)
+	if err != nil {
+		return err
+	}
+	expireSeconds := int(expire.Seconds())
+	if expireSeconds == 0 {
+		expireSeconds = 1
+	}
+	return store.cache.Set([]byte(key), payload, expireSeconds)
+}
+
+func (store *FreeCacheStore) Get(ctx context.Context, key string, value interface{}) error {
+	payload, err := store.cache.Get([]byte(key))
+	if err != nil {
+		if errors.Is(err, freecache.ErrNotFound) {
+			return ErrCacheMiss
+		}
+		return err
+	}
+	return Deserialize(payload, value)
+}
+
+func (store *FreeCacheStore) Delete(ctx context.Context, key string) error {
+	store.cache.Del([]byte(key))
+	return nil
+}

--- a/persist/freecache_test.go
+++ b/persist/freecache_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 cyhone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+* This file may have been modified by CloudWeGo authors. All CloudWeGo
+* Modifications are Copyright 2022 CloudWeGo Authors.
+*/
+
+package persist
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
+
+func TestFreeCacheStore(t *testing.T) {
+	freecacheStore := NewFreeCacheStore(10 * 1024 * 1024)
+
+	ctx := context.Background()
+	expectVal := "123"
+	assert.Nil(t, freecacheStore.Set(ctx, "test", expectVal, 1*time.Second))
+
+	value := ""
+	assert.Nil(t, freecacheStore.Get(ctx, "test", &value))
+	assert.DeepEqual(t, expectVal, value)
+
+	time.Sleep(1 * time.Second)
+	assert.DeepEqual(t, ErrCacheMiss, freecacheStore.Get(ctx, "test", &value))
+
+	freecacheStore.Set(ctx, "test", "value", 1*time.Second)
+	assert.Nil(t, freecacheStore.Get(ctx, "test", &value))
+	assert.DeepEqual(t, "value", value)
+	freecacheStore.Delete(ctx, "test")
+	assert.DeepEqual(t, ErrCacheMiss, freecacheStore.Get(ctx, "test", &value))
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: This PR adds a FreeCacheStore adapter to the cache middleware. Why we need it: freecache is very popular in the Go community with a high number of stars on GitHub, and many developers use it for local caching. However, the current Hertz cache middleware does not have an adapter for it yet. This PR adds the support to fill this gap.
zh:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
